### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/internal/userrepo/mongo/userrepo.go
+++ b/internal/userrepo/mongo/userrepo.go
@@ -17,6 +17,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const (
+	MAXLENGTH_USERNAME = 64 // Maximum length for username
+)
+
 // MongoUserRepository implements UserRepository using the generic DBClient.
 type MongoUserRepository struct {
 	dbClient interfaces.DBClient // Here we use the concrete Mongo implementation of DBClient
@@ -66,6 +70,11 @@ func (r *MongoUserRepository) AddUser(ctx context.Context, user models.User) (st
 
 // GetUserByUsername retrieves a user from MongoDB via DBClient.
 func (r *MongoUserRepository) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
+	// Validate the username
+	if len(username) == 0 || len(username) > MAXLENGTH_USERNAME {
+		return nil, fmt.Errorf("invalid username: must be between 1 and %d characters", MAXLENGTH_USERNAME)
+	}
+
 	var mongoUser struct { // Temporary struct to decode MongoDB BSON
 		ID       primitive.ObjectID `bson:"_id,omitempty"`
 		Username string             `bson:"username"`


### PR DESCRIPTION
Potential fix for [https://github.com/haguru/sasuke/security/code-scanning/4](https://github.com/haguru/sasuke/security/code-scanning/4)

To fix the issue, we need to validate and sanitize the user-provided input before using it in the MongoDB query. Specifically:
1. Ensure that the `username` field (or any other user-controlled input) is validated for expected format and length before constructing the `filter`.
2. Use a strict schema or validation library to enforce constraints on the input data.
3. Modify the `GetUserByUsername` method in `internal/userrepo/mongo/userrepo.go` to validate the `username` before constructing the `filter`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
