### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
 name: Tests
 on: [pull_request]
+permissions:
+  contents: read
 env:
   REVIEWDOG_FAIL_ON_ERROR: 'true'
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/haguru/sasuke/security/code-scanning/2](https://github.com/haguru/sasuke/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the job is running unit tests and does not appear to require write access, the minimal permissions required are `contents: read`. This will restrict the workflow's access to read-only operations on the repository contents. The `permissions` block can be added either at the root of the workflow (to apply to all jobs) or within the specific job (`unit-tests`) to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
