### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -1,5 +1,7 @@
 name: reviewdog
 on: [pull_request]
+permissions:
+  contents: read
 env:
   REVIEWDOG_FAIL_ON_ERROR: 'true'
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/haguru/sasuke/security/code-scanning/1](https://github.com/haguru/sasuke/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient for most steps, while specific actions may require additional permissions (e.g., `pull-requests: write` for reviewdog tools interacting with pull requests).

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. This change does not alter the functionality of the workflow but enhances its security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
